### PR TITLE
Add a mysql-listen-port configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ run: $(BIN)/$(app)
 		-mysql-idle-timeout=5s \
 		-mysql-no-pass \
 		-mysql-max-rows=1000 \
-		-mysql-dbname=mysql
+		-mysql-dbname=mysql \
+		-mysql-listen-port=3309
 
 docker:
 	docker buildx build --target=local --rm -t $(app) .


### PR DESCRIPTION
This runs a simply TCP proxy that doesn't modify any packets, but simply acts as a proxy back to the upstream MySQL server.

This enables a single entrypoint/hostname to handle both HTTP and MySQL connections.