### PR TITLE
Exposes a log level option to the command line interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ run: $(BIN)/$(app)
 	$< \
 		-listen-addr=127.0.0.1 \
 		-listen-port=8080 \
+		-log-level=debug \
 		-mysql-addr=127.0.0.1 \
 		-mysql-port=3306 \
 		-mysql-idle-timeout=5s \

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Compiled binaries can be found in GitHub Releases: https://github.com/mattrobeno
 Images are published to [ghcr.io/mattrobenolt/ps-http-sim:latest](https://github.com/mattrobenolt/ps-http-sim/pkgs/container/ps-http-sim)
 
 ### docker-compose
+
 A sample docker-compose.yml is available in the examples folder.
 This will spin up a mysql server on the default port of 3306, and ps-http-sim on port 3900.
 
@@ -52,6 +53,8 @@ Usage of ps-http-sim:
         HTTP server address (default "127.0.0.1")
   -listen-port uint
         HTTP server port (default 8080)
+  -log-level string
+        Log level (debug, info, warn, error, dpanic, panic, fatal) (default "debug")
   -mysql-addr string
         MySQL address (default "127.0.0.1")
   -mysql-dbname string

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ var (
 
 	flagListenAddr       = commandLine.String("listen-addr", "127.0.0.1", "HTTP server address")
 	flagListenPort       = commandLine.Uint("listen-port", 8080, "HTTP server port")
+	flagLogLevel         = commandLine.String("log-level", "debug", "Log level (debug, info, warn, error)")
 	flagMySQLAddr        = commandLine.String("mysql-addr", "127.0.0.1", "MySQL address")
 	flagMySQLPort        = commandLine.Uint("mysql-port", 3306, "MySQL port")
 	flagMySQLNoPass      = commandLine.Bool("mysql-no-pass", false, "Don't use password for MySQL connection")
@@ -259,7 +260,13 @@ func init() {
 var logger *log.Logger
 
 func main() {
-	cfg := log.NewPlanetScaleConfig("pretty", log.DebugLevel)
+	level, err := log.ParseLevel(*flagLogLevel)
+	if err != nil {
+		fmt.Printf("Invalid log level '%s', defaulting to 'debug'\n", *flagLogLevel)
+		level = log.DebugLevel
+	}
+
+	cfg := log.NewPlanetScaleConfig("pretty", level)
 	logger, _ = cfg.Build()
 	defer logger.Sync()
 


### PR DESCRIPTION
Currently `ps-http-sim` logs are flooding our CI logs which makes it difficult to find real errors we should pay attention to. These changes expose a `log-level` option so the amount of outputted logs can be set the desired level.